### PR TITLE
Fix paths for installed package

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,28 +59,28 @@ To run this example, start Julia and execute the following:
 ```julia
 julia> using KROME
 
-julia> include(joinpath(examples_dir(), "test_hello", "test_hello.jl"));
+julia> include(joinpath(KROME.examples_dir(), "test_hello", "test_hello.jl"));
 
 julia> test_hello()
-Test OK!
-In gnuplot type
- load 'plot.gps'
-
-julia> println(read("julia.66", String))
 ```
-This will print out the contents of the newly created file `julia.66`.
+This will print out the abundancies as the chemical network evolves in time. To
+store the results in a file, e.g., `test_hello.txt`, change the last line of the
+snippet above to
+```julia
+julia> open("test_hello.txt", "w+") do io; test_hello(io); end
+```
 
 ### av-slab-benchmark
 To run this example, you first need to build KROME.jl with a different network
 file by executing
 ```shell
-KROME_NETWORK_FILE=$(julia -e 'using KROME; println(joinpath(examples_dir(), "av-slab-benchmark", "react_chnet5"))') \
+KROME_NETWORK_FILE=$(julia -e 'using KROME; println(joinpath(KROME.examples_dir(), "av-slab-benchmark", "react_chnet5"))') \
   JULIA_KROME_CUSTOM_ARGS="-n;$KROME_NETWORK_FILE;-noRecCheck" \
   julia -e 'using Pkg; Pkg.build("KROME")'
 ```
 The command
 ```shell
-julia -e 'using KROME; println(joinpath(examples_dir(), "av-slab-benchmark", "react_chnet5"))'
+julia -e 'using KROME; println(joinpath(KROME.examples_dir(), "av-slab-benchmark", "react_chnet5"))'
 ```
 is used here to obtain the path to the chemical network file from the
 corresponding example directory of the KROME.jl package.
@@ -89,7 +89,7 @@ After re-building KROME.jl successfully, start Julia and execute the following:
 ```julia
 julia> using KROME
 
-julia> include(joinpath(examples_dir(), "av-slab-benchmark", "av_slab.jl"))
+julia> include(joinpath(KROME.examples_dir(), "av-slab-benchmark", "av_slab.jl"))
 
 julia> av_slab()
 ```

--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ by KROME.
 
 
 ## Installation
-Clone this package, enter the package directory, and build the package:
+If you have not yet installed Julia, please [follow the instructions for your
+operating system](https://julialang.org/downloads/platform/). KROMEjl works
+with Julia v1.5.
+
+You can then install KROME.jl by executing
 ```shell
-git clone git@github.com:trixi-framework/KROME.jl.git
-cd KROME.jl
-julia --project=. -e 'using Pkg; Pkg.build()'
+julia -e 'using Pkg; Pkg.add("KROME")'
 ```
 
 By default, this will build the KROME library with the `hello` test activated,
@@ -43,7 +45,7 @@ will be passed to the `krome` preprocessor. For example, to provide a custom
 network file while disabling the recombinations check, you can run the build
 command above with
 ```shell
-JULIA_KROME_CUSTOM_ARGS="-n;abs/path/to/react_skynet;-noRecCheck" julia --project=. -e 'using Pkg; Pkg.build()'
+JULIA_KROME_CUSTOM_ARGS="-n;abs/path/to/react_skynet" julia -e 'using Pkg; Pkg.build("KROME")'
 ```
 Please note that you have to specify the *absolute* path to the network file.
 
@@ -52,34 +54,42 @@ Please note that you have to specify the *absolute* path to the network file.
 Have a look at the examples in [examples/](examples/) to find out how to use
 KROME.jl. Right now there are two examples available.
 
-### `test_hello`
-To run this example, enter the package directory, start Julia with `julia
---project`, and execute the following:
+### test_hello
+To run this example, start Julia and execute the following:
 ```julia
-julia> isfile("examples/test_hello/julia.66")
-false
+julia> using KROME
 
-julia> include("examples/test_hello/test_hello.jl");
+julia> include(joinpath(examples_dir(), "test_hello", "test_hello.jl"));
 
 julia> test_hello()
 Test OK!
 In gnuplot type
  load 'plot.gps'
 
-julia> println(read("examples/test_hello/julia.66", String))
+julia> println(read("julia.66", String))
 ```
 This will print out the contents of the newly created file `julia.66`.
 
-### `av-slab-benchmark`
-To run this example, you first need to build KROME with a different network
-file. Enter the package directory and execute
+### av-slab-benchmark
+To run this example, you first need to build KROME.jl with a different network
+file by executing
 ```shell
-JULIA_KROME_CUSTOM_ARGS="-n;$(pwd)/examples/av-slab-benchmark/react_chnet5;-noRecCheck" julia --project=. -e 'using Pkg; Pkg.build()'
+KROME_NETWORK_FILE=$(julia -e 'using KROME; println(joinpath(examples_dir(), "av-slab-benchmark", "react_chnet5"))') \
+  JULIA_KROME_CUSTOM_ARGS="-n;$KROME_NETWORK_FILE;-noRecCheck" \
+  julia -e 'using Pkg; Pkg.build("KROME")'
 ```
-After re-building KROME successfully, start Julia with `julia --project` and
-execute the following:
+The command
+```shell
+julia -e 'using KROME; println(joinpath(examples_dir(), "av-slab-benchmark", "react_chnet5"))'
+```
+is used here to obtain the path to the chemical network file from the
+corresponding example directory of the KROME.jl package.
+
+After re-building KROME.jl successfully, start Julia and execute the following:
 ```julia
-julia> include("examples/av-slab-benchmark/av_slab.jl")
+julia> using KROME
+
+julia> include(joinpath(examples_dir(), "av-slab-benchmark", "av_slab.jl"))
 
 julia> av_slab()
 ```

--- a/examples/test_hello/test_hello.jl
+++ b/examples/test_hello/test_hello.jl
@@ -18,7 +18,7 @@
 using KROME
 using Printf
 
-function test_hello()
+function test_hello(io::IO=stdout)
   cd(@__DIR__) do
     install_reactions_verbatim()
 
@@ -33,25 +33,19 @@ function test_hello()
     dt = fill(1e-5) # time-step (arbitrary)
     t = 0.0 # time (arbitrary)
 
-    open("julia.66", "w") do io
-      println(io, "#time  FK1 FK2 FK3")
-      while true
-        dt[] = dt[] * 1.1 # increase timestep
-        krome(x, Tgas, dt) # call KROME
-        print(io, fsn(t))
-        for value in x
-          print(io, fsn(value))
-        end
-        println(io)
-        t = t + dt[] # increase time
-        t > 5 && break # break loop after 5 time units
+    println(io, "#time  FK1 FK2 FK3")
+    while true
+      dt[] = dt[] * 1.1 # increase timestep
+      krome(x, Tgas, dt) # call KROME
+      print(io, fsn(t))
+      for value in x
+        print(io, fsn(value))
       end
+      println(io)
+      t = t + dt[] # increase time
+      t > 5 && break # break loop after 5 time units
     end
   end
-
-  println("Test OK!")
-  println("In gnuplot type")
-  println(" load 'plot.gps'")
 end
 
 # Return formatted value in Fortran scientific notation

--- a/src/KROME.jl
+++ b/src/KROME.jl
@@ -5,7 +5,7 @@ using CBinding: 𝐣𝐥
 
 include("libkrome.jl")
 
-export install_reactions_verbatim
+export install_reactions_verbatim, examples_dir
 
 
 """
@@ -28,5 +28,23 @@ function install_reactions_verbatim(dir="."; force=true)
 
   return target_path
 end
+
+
+"""
+    examples_dir()
+
+Return the directory where the examples provided with KROME.jl are located. If KROME is
+installed as a regular package (with `]add KROME`), these files are read-only and should *not* be
+modified. To find out which files are available, use, e.g., `readdir`:
+
+# Examples
+```julia
+julia> readdir(examples_dir())
+2-element Array{String,1}:
+ "av-slab-benchmark"
+ "test_hello"
+```
+"""
+examples_dir() = joinpath(pathof(KROME) |> dirname |> dirname, "examples")
 
 end

--- a/src/KROME.jl
+++ b/src/KROME.jl
@@ -5,7 +5,7 @@ using CBinding: 𝐣𝐥
 
 include("libkrome.jl")
 
-export install_reactions_verbatim, examples_dir
+export install_reactions_verbatim
 
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ mkdir(outdir)
 end
 
 @testset "examples_dir" begin
-  @test basename(examples_dir()) == "examples"
+  @test basename(KROME.examples_dir()) == "examples"
 end
 
 # need to change to outdir to have `reactions_verbatim.dat` present

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,10 @@ mkdir(outdir)
   @test isfile(joinpath(outdir, "reactions_verbatim.dat"))
 end
 
+@testset "examples_dir" begin
+  @test basename(examples_dir()) == "examples"
+end
+
 # need to change to outdir to have `reactions_verbatim.dat` present
 @testset "change directory" begin
   @test_nowarn cd(outdir)


### PR DESCRIPTION
This PR fixes the README and adds a new function `examples_dir` to account for the fact that KROME is now a registered package.