### PR TITLE
simplify CI cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,16 +41,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v1
       - name: Set up gfortran-10 as gfortran and gcc-10 as gcc (macOS only)
         if: contains(matrix.os, 'macOS')
         run: |


### PR DESCRIPTION
This uses a new GitHub action https://github.com/marketplace/actions/cache-julia-artifacts-packages-and-registry made specifically for this purpose, see also https://discourse.julialang.org/t/recommendation-cache-julia-artifacts-in-ci-services/35484/8.
Xref trixi-framework/Trixi.jl#1027